### PR TITLE
[CU-86b5kmnvg] Update deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ This library is published to Maven Central. The deployment process is automated 
 
 ### Build Pipeline
 
-Commits trigger builds in the [libraries-build pipeline](https://concourse.tools.dnastack.com/teams/dev/pipelines/libraries-build).
+Commits trigger builds in the libraries-build pipeline.
 
 ### Release Process
 

--- a/README.md
+++ b/README.md
@@ -86,3 +86,35 @@ E2E_WALLET_TOKEN_URI
 E2E_WALLET_CLIENT_ID
 E2E_WALLET_CLIENT_SECRET
 ```
+
+## Deployment Process
+
+This library is published to Maven Central. The deployment process is automated using Concourse CI.
+
+### Build Pipeline
+
+Commits trigger builds in the [libraries-build pipeline](https://concourse.tools.dnastack.com/teams/dev/pipelines/libraries-build).
+
+### Release Process
+
+1. **Create a SNAPSHOT tag**: Create an annotated tag on the main branch for the next release with the SNAPSHOT postfix (e.g., `1.2.1-SNAPSHOT`)
+   ```bash
+   git tag -a 1.2.1-SNAPSHOT -m "Start development of version 1.2.1"
+   git push origin 1.2.1-SNAPSHOT
+   ```
+
+2. **Development**: Branch, commit, push, and create pull requests as usual
+
+3. **Release**: When the current snapshot is ready to become a release, create the release tag (e.g., `1.2.1`)
+   ```bash
+   git tag -a 1.2.1 -m "Release version 1.2.1"
+   git push origin 1.2.1
+   ```
+
+4. **Next development cycle**: Once the release build completes and the new release is available on Maven Central, tag the current commit with the next release version's SNAPSHOT
+   ```bash
+   git tag -a 1.2.2-SNAPSHOT -m "Start development of version 1.2.2"
+   git push origin 1.2.2-SNAPSHOT
+   ```
+
+**Note**: Tags must match the regex `^[0-9]+\.[0-9]+\.[0-9]+$` to trigger a release build.


### PR DESCRIPTION
## Summary
This PR updates the README.md file to reflect the new automated deployment process for publishing to Maven Central.

## Changes
- Added a new "Deployment Process" section to the README
- Documented the automated Concourse CI build pipeline
- Provided clear instructions for the release workflow:
  - Creating SNAPSHOT tags for development versions
  - Creating release tags to trigger Maven Central deployment
  - Managing the development cycle with proper version tagging
- Included the regex requirement for release tags (`^[0-9]+\.[0-9]+\.[0-9]+$`)

## Context
All libraries in this repository are now published to Maven Central through an automated process. The previous manual deployment instructions have been replaced with the new streamlined workflow that uses:
- Concourse CI for builds (triggered on commits)
- Annotated Git tags for version management
- Automated deployment to Maven Central on release tags

## Release Process Overview
1. Create SNAPSHOT tag (e.g., `1.2.1-SNAPSHOT`)
2. Develop and merge changes as usual
3. Create release tag (e.g., `1.2.1`) 
4. Tag next SNAPSHOT after release completes

This standardizes the deployment process across all DNAstack libraries.